### PR TITLE
Fixing supposed variable name conflict

### DIFF
--- a/authorizer/utils.go
+++ b/authorizer/utils.go
@@ -41,8 +41,8 @@ func Authorize(db *database.Database, w http.ResponseWriter,
 			sig:     sig,
 		}
 	} else {
-		cook, sess, err := auth.CookieSession(db, w, r)
-		if err != nil {
+		cook, sess, e := auth.CookieSession(db, w, r)
+		if e != nil {
 			return
 		}
 


### PR DESCRIPTION
`err` was shadowed during return