### PR TITLE
Update default Service object

### DIFF
--- a/mhandlers/service.go
+++ b/mhandlers/service.go
@@ -104,8 +104,12 @@ func servicePost(c *gin.Context) {
 
 	db := c.MustGet("db").(*database.Database)
 	data := &serviceData{
-		Name:         "New Service",
-		ShareSession: true,
+		Name:              "New Service",
+		ShareSession:      true,
+		Domains:           make([]*service.Domain, 0),
+		Roles:             make([]string, 0),
+		Servers:           make([]*service.Server, 0),
+		WhitelistNetworks: make([]string, 0),
 	}
 
 	err := c.Bind(data)


### PR DESCRIPTION
Currently, the new `Service` record is going into MongoDB like this:
```
rs0:PRIMARY> db.services.findOne({"name":"New Service",domains: null})
{
        "_id" : ObjectId("5d2a79df2514747584e8bb09"),
        "name" : "New Service",
        "type" : "",
        "share_session" : true,
        "logout_path" : "",
        "websockets" : true,
        "disable_csrf_check" : false,
        "domains" : null,
        "roles" : null,
        "servers" : null,
        "whitelist_networks" : null
}
```

This is causing errors like:
```
app.7e994f.js:36753 TypeError: Cannot read property 'length' of null
    at Service.render (app.7e994f.js:13901)
    at xg (app.7e994f.js:36626)
    at wg (app.7e994f.js:36623)
    at Ag (app.7e994f.js:36671)
    at lh (app.7e994f.js:37014)
    at mh (app.7e994f.js:37019)
    at Ph (app.7e994f.js:37175)
    at Qh (app.7e994f.js:37162)
    at sh (app.7e994f.js:37133)
    at Uf (app.7e994f.js:37092)
```

On lines like:
```
for (let i = 0; i < service.domains.length; i++) {
```
By setting an explicit empty array for the new records, this will address the issue at its lowest level. We could have updated the UI to handle nulls as well, but this approach felt more appropriate in keeping the UI as a thin, and dumb client.