### PR TITLE
Fix for impossibility of choosing date in next year

### DIFF
--- a/www/app/components/PageDateTime.tsx
+++ b/www/app/components/PageDateTime.tsx
@@ -53,6 +53,7 @@ export default class PageDateTime extends React.Component<Props, {}> {
 						}}
 						datePickerProps={{
 							showActionsBar: true,
+							maxDate: new Date(new Date().getFullYear() + 1, 11, 31).getTime()
 						}}
 						onChange={(newDate: Date): void => {
 							if (this.props.disabled) {


### PR DESCRIPTION
A tiny fix for the impossibility of choosing an account deactivation date ("active until" functionality) in next year due to the default value (Dec. 31st of this year.) ​​of the maxDate property in the datepicker component, see the [Documentation](https://blueprintjs.com/docs/#datetime/datepicker).

It's not a problem in most cases, but it leads to such rare inconvenient case as the current one (when the next year is too close) - we aren't able to set an expiration date of our users accounts to the next year. The most latest deactivation date we can set for all of them is dec. 31st of this year only.

Proposed fix takes into account at least the following year.