### PR TITLE
Use Ed25519 algorithm instead of RSA for bastion host key

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 pritunl-zero changelog
 ======================
 
+<%= version %>
+
+Use Ed25519 algorithm instead of RSA for bastion host key
+
 Version 1.0.2520.78 2022-10-18
 ------------------------------
 

--- a/authority/authority.go
+++ b/authority/authority.go
@@ -95,14 +95,14 @@ func (a *Authority) GetDomain(hostname string) string {
 	return hostname + "." + a.HostDomain
 }
 
-func (a *Authority) GenerateRsaProxyPrivateKey() (err error) {
-	privKeyBytes, pubKeyBytes, err := GenerateRsaKey()
+func (a *Authority) GenerateEdProxyPrivateKey() (err error) {
+	privKeyBytes, pubKeyBytes, err := GenerateEdKey()
 	if err != nil {
 		return
 	}
 
 	a.Info = &Info{
-		KeyAlg: "RSA 4096",
+		KeyAlg: "Ed25519",
 	}
 	a.ProxyPrivateKey = strings.TrimSpace(string(privKeyBytes))
 	a.ProxyPublicKey = strings.TrimSpace(string(pubKeyBytes))

--- a/bastion/bastion.go
+++ b/bastion/bastion.go
@@ -96,7 +96,7 @@ func (b *Bastion) renewHost(db *database.Database) (err error) {
 		return
 	}
 
-	hostCertPath := filepath.Join(b.path, "ssh_host_rsa_key-cert.pub")
+	hostCertPath := filepath.Join(b.path, "ssh_host_key-cert.pub")
 
 	if len(cert.Certificates) == 0 || len(cert.CertificatesInfo) == 0 {
 		err = &errortypes.UnknownError{
@@ -133,7 +133,7 @@ func (b *Bastion) Start(db *database.Database,
 	b.path = utils.GetTempPath()
 
 	if authr.ProxyPublicKey == "" || authr.ProxyPrivateKey == "" {
-		err = authr.GenerateRsaProxyPrivateKey()
+		err = authr.GenerateEdProxyPrivateKey()
 		if err != nil {
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.5.0
+	github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a
 	github.com/opensearch-project/opensearch-go v1.1.0
 	github.com/pritunl/mongo-go-driver v0.0.0-20210816062132-f388bdb66274
 	github.com/pritunl/webauthn v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -468,6 +468,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOmkVoJOpwnS0wfdsJCV9CoD5nJYsHoFk/0CrTK4M=
@@ -738,6 +739,8 @@ github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKju
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a h1:eU8j/ClY2Ty3qdHnn0TyW3ivFoPC/0F1gQZz8yTxbbE=
+github.com/mikesmitty/edkey v0.0.0-20170222072505-3356ea4e686a/go.mod h1:v8eSC2SMp9/7FTKUncp7fH9IwPfw+ysMObcEz5FWheQ=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=


### PR DESCRIPTION
Some of our users upgraded to macOS Ventura that comes with OpenSSH 9.0p1, and can't connect to bastion hosts anymore, apparently due to the disabled RSA signatures using the SHA-1 hash algorithm by default since [OpenSSH 8.8](https://www.openssh.com/txt/release-8.8). Ed25519 is a modern and much more secure algorithm that is becoming widely used as a better alternative to RSA.

Tested on clients with macOS Monterey and Ventura.

Any existing RSA keys won't be re-generated, so should not cause any trouble for existing clients.

I also changed `ssh_host_rsa_key-cert.pub` to a generic `ssh_host_key-cert.pub` (see https://github.com/pritunl/pritunl-bastion/pull/1), so that the algorithm could be changed without having to change the bastion docker image.