### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/alert/utils.go
+++ b/alert/utils.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/bson/primitive"
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, alertId primitive.ObjectID) (
@@ -121,8 +120,8 @@ func GetAllPaged(db *database.Database, query *bson.M,
 	if count == pageCount {
 		maxPage = 0
 	}
-	page = utils.Min64(page, maxPage)
-	skip := utils.Min64(page*pageCount, count)
+	page = min(page, maxPage)
+	skip := min(page*pageCount, count)
 
 	cursor, err := coll.Find(
 		db,

--- a/audit/utils.go
+++ b/audit/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pritunl/pritunl-zero/database"
 	"github.com/pritunl/pritunl-zero/settings"
 	"github.com/pritunl/pritunl-zero/useragent"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, adtId string) (
@@ -52,8 +51,8 @@ func GetAll(db *database.Database, userId primitive.ObjectID,
 		if count == pageCount {
 			maxPage = 0
 		}
-		page = utils.Min64(page, maxPage)
-		skip := utils.Min64(page*pageCount, count)
+		page = min(page, maxPage)
+		skip := min(page*pageCount, count)
 		opts.Skip = &skip
 		opts.Limit = &pageCount
 	}

--- a/check/utils.go
+++ b/check/utils.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/bson/primitive"
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, checkId primitive.ObjectID) (
@@ -121,8 +120,8 @@ func GetAllPaged(db *database.Database, query *bson.M,
 	if count == pageCount {
 		maxPage = 0
 	}
-	page = utils.Min64(page, maxPage)
-	skip := utils.Min64(page*pageCount, count)
+	page = min(page, maxPage)
+	skip := min(page*pageCount, count)
 
 	cursor, err := coll.Find(
 		db,

--- a/endpoint/utils.go
+++ b/endpoint/utils.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/bson/primitive"
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, endpointId primitive.ObjectID) (
@@ -120,8 +119,8 @@ func GetAllPaged(db *database.Database, query *bson.M,
 	if count == pageCount {
 		maxPage = 0
 	}
-	page = utils.Min64(page, maxPage)
-	skip := utils.Min64(page*pageCount, count)
+	page = min(page, maxPage)
+	skip := min(page*pageCount, count)
 
 	cursor, err := coll.Find(
 		db,

--- a/log/utils.go
+++ b/log/utils.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
 	"github.com/pritunl/pritunl-zero/event"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, logId primitive.ObjectID) (
@@ -54,8 +53,8 @@ func GetAll(db *database.Database, query *bson.M, page, pageCount int64) (
 		if count == pageCount {
 			maxPage = 0
 		}
-		page = utils.Min64(page, maxPage)
-		skip := utils.Min64(page*pageCount, count)
+		page = min(page, maxPage)
+		skip := min(page*pageCount, count)
 		opts.Skip = &skip
 		opts.Limit = &pageCount
 	}

--- a/node/utils.go
+++ b/node/utils.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/bson/primitive"
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, nodeId primitive.ObjectID) (
@@ -78,8 +77,8 @@ func GetAllPaged(db *database.Database, query *bson.M,
 	if count == pageCount {
 		maxPage = 0
 	}
-	page = utils.Min64(page, maxPage)
-	skip := utils.Min64(page*pageCount, count)
+	page = min(page, maxPage)
+	skip := min(page*pageCount, count)
 
 	cursor, err := coll.Find(
 		db,

--- a/service/utils.go
+++ b/service/utils.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/bson/primitive"
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, serviceId primitive.ObjectID) (
@@ -155,8 +154,8 @@ func GetAllPaged(db *database.Database, query *bson.M,
 	if count == pageCount {
 		maxPage = 0
 	}
-	page = utils.Min64(page, maxPage)
-	skip := utils.Min64(page*pageCount, count)
+	page = min(page, maxPage)
+	skip := min(page*pageCount, count)
 
 	cursor, err := coll.Find(
 		db,

--- a/ssh/certificate.go
+++ b/ssh/certificate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pritunl/pritunl-zero/settings"
 	"github.com/pritunl/pritunl-zero/user"
 	"github.com/pritunl/pritunl-zero/useragent"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 type Info struct {
@@ -119,8 +118,8 @@ func GetCertificates(db *database.Database, userId primitive.ObjectID,
 		if count == pageCount {
 			maxPage = 0
 		}
-		page = utils.Min64(page, maxPage)
-		skip := utils.Min64(page*pageCount, count)
+		page = min(page, maxPage)
+		skip := min(page*pageCount, count)
 		opts.Skip = &skip
 		opts.Limit = &pageCount
 	}

--- a/user/utils.go
+++ b/user/utils.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pritunl/mongo-go-driver/mongo/options"
 	"github.com/pritunl/pritunl-zero/database"
 	"github.com/pritunl/pritunl-zero/errortypes"
-	"github.com/pritunl/pritunl-zero/utils"
 )
 
 func Get(db *database.Database, userId primitive.ObjectID) (
@@ -138,8 +137,8 @@ func GetAll(db *database.Database, query *bson.M, page, pageCount int64) (
 		if count == pageCount {
 			maxPage = 0
 		}
-		page = utils.Min64(page, maxPage)
-		skip := utils.Min64(page*pageCount, count)
+		page = min(page, maxPage)
+		skip := min(page*pageCount, count)
 		opts.Skip = &skip
 		opts.Limit = &pageCount
 	}

--- a/utils/math.go
+++ b/utils/math.go
@@ -4,34 +4,6 @@ import (
 	"math"
 )
 
-func Max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func Min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
-func Max64(x, y int64) int64 {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-func Min64(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 func ToFixed(x float64, p int) float64 {
 	y := math.Pow(10, float64(p))
 	return float64(int(x*y+math.Copysign(0.5, x*y))) / y


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max