### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/x509"
+	"slices"
 	"strings"
 	"time"
 
@@ -258,13 +259,7 @@ func (d *Device) CheckLevel(level int) bool {
 		return false
 	}
 
-	for _, lvl := range d.AlertLevels {
-		if level == lvl {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(d.AlertLevels, level)
 }
 
 func (d *Device) Commit(db *database.Database) (err error) {

--- a/node/node.go
+++ b/node/node.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -85,10 +86,8 @@ func (n *Node) AddType(nodeType string) bool {
 	}
 
 	types := strings.Split(n.Type, "_")
-	for _, typ := range types {
-		if typ == nodeType {
-			return false
-		}
+	if slices.Contains(types, nodeType) {
+		return false
 	}
 
 	types = append(types, nodeType)
@@ -170,13 +169,7 @@ func (n *Node) GetWebauthn(origin string, strict bool) (
 }
 
 func (n *Node) HasService(srvcId primitive.ObjectID) bool {
-	for _, serviceId := range n.Services {
-		if serviceId == srvcId {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(n.Services, srvcId)
 }
 
 func (n *Node) AddService(srvcId primitive.ObjectID) bool {
@@ -200,10 +193,8 @@ func (n *Node) RemoveService(srvcId primitive.ObjectID) bool {
 }
 
 func (n *Node) HasCertificate(certId primitive.ObjectID) bool {
-	for _, certObjId := range n.Certificates {
-		if certObjId == certId {
-			return false
-		}
+	if slices.Contains(n.Certificates, certId) {
+		return false
 	}
 
 	return false

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/pritunl/pritunl-zero/useragent"
@@ -417,13 +418,7 @@ func (p *Policy) ValidateUser(db *database.Database, usr *user.User,
 }
 
 func (p *Policy) HasService(srvcId primitive.ObjectID) bool {
-	for _, serviceId := range p.Services {
-		if serviceId == srvcId {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(p.Services, srvcId)
 }
 
 func (p *Policy) AddService(srvcId primitive.ObjectID) bool {

--- a/task/task.go
+++ b/task/task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/pritunl/pritunl-zero/database"
@@ -33,10 +34,8 @@ type Task struct {
 func (t *Task) scheduled(hour, min int) bool {
 	for _, h := range t.Hours {
 		if h == hour {
-			for _, m := range t.Minutes {
-				if m == min {
-					return true
-				}
+			if slices.Contains(t.Minutes, min) {
+				return true
 			}
 		}
 	}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.