### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/acme/utils.go
+++ b/acme/utils.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
@@ -65,11 +66,9 @@ func DnsTxtWait(domain, val string) (found bool, err error) {
 			continue
 		}
 
-		for _, record := range records {
-			if record == val {
-				found = true
-				return
-			}
+		if slices.Contains(records, val) {
+			found = true
+			return
 		}
 	}
 

--- a/authority/authority.go
+++ b/authority/authority.go
@@ -21,6 +21,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -411,14 +412,7 @@ func (a *Authority) createCertificateLocal(
 
 	roles := usr.Roles
 	if a.JumpProxy() != "" {
-		hasBastion := false
-
-		for _, role := range roles {
-			if role == "bastion" {
-				hasBastion = true
-				break
-			}
-		}
+		hasBastion := slices.Contains(roles, "bastion")
 
 		if !hasBastion {
 			roles = append(usr.Roles, "bastion")
@@ -493,14 +487,7 @@ func (a *Authority) createCertificateHsm(db *database.Database,
 
 	roles := usr.Roles
 	if a.JumpProxy() != "" {
-		hasBastion := false
-
-		for _, role := range roles {
-			if role == "bastion" {
-				hasBastion = true
-				break
-			}
-		}
+		hasBastion := slices.Contains(roles, "bastion")
 
 		if !hasBastion {
 			roles = append(usr.Roles, "bastion")

--- a/cmd/upsert_policy.go
+++ b/cmd/upsert_policy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/dropbox/godropbox/container/set"
 	"github.com/pritunl/mongo-go-driver/bson"
@@ -157,13 +158,7 @@ var UpsertPolicyCmd = &cobra.Command{
 					return
 				}
 
-				found := false
-				for _, serviceId := range pol.Services {
-					if serviceId == srvc.Id {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(pol.Services, srvc.Id)
 
 				if !found {
 					pol.Services = append(pol.Services, srvc.Id)
@@ -213,13 +208,7 @@ var UpsertPolicyCmd = &cobra.Command{
 					return
 				}
 
-				found := false
-				for _, authorityId := range pol.Authorities {
-					if authorityId == auth.Id {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(pol.Authorities, auth.Id)
 
 				if !found {
 					pol.Authorities = append(pol.Authorities, auth.Id)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -227,13 +227,7 @@ func (p *Policy) ValidateUser(db *database.Database, usr *user.User,
 	for _, rule := range p.Rules {
 		switch rule.Type {
 		case OperatingSystem:
-			match := false
-			for _, value := range rule.Values {
-				if value == agnt.OperatingSystem {
-					match = true
-					break
-				}
-			}
+			match := slices.Contains(rule.Values, agnt.OperatingSystem)
 
 			if !match {
 				if rule.Disable {
@@ -257,13 +251,7 @@ func (p *Policy) ValidateUser(db *database.Database, usr *user.User,
 			}
 			break
 		case Browser:
-			match := false
-			for _, value := range rule.Values {
-				if value == agnt.Browser {
-					match = true
-					break
-				}
-			}
+			match := slices.Contains(rule.Values, agnt.Browser)
 
 			if !match {
 				if rule.Disable {

--- a/u2flib/util.go
+++ b/u2flib/util.go
@@ -12,33 +12,33 @@ database.
 
 To enrol a new token:
 
-    app_id := "http://localhost"
-    c, _ := NewChallenge(app_id, []string{app_id})
-    req, _ := u2f.NewWebRegisterRequest(c, existingTokens)
-    // Send the request to the browser.
-    var resp RegisterResponse
-    // Read resp from the browser.
-    reg, err := Register(resp, c)
-    if err != nil {
-         // Registration failed.
-    }
-    // Store reg in the database.
+	app_id := "http://localhost"
+	c, _ := NewChallenge(app_id, []string{app_id})
+	req, _ := u2f.NewWebRegisterRequest(c, existingTokens)
+	// Send the request to the browser.
+	var resp RegisterResponse
+	// Read resp from the browser.
+	reg, err := Register(resp, c)
+	if err != nil {
+	     // Registration failed.
+	}
+	// Store reg in the database.
 
 To perform an authentication:
 
-    var regs []Registration
-    // Fetch regs from the database.
-    c, _ := NewChallenge(app_id, []string{app_id})
-    req, _ := c.SignRequest(regs)
-    // Send the request to the browser.
-    var resp SignResponse
-    // Read resp from the browser.
-    new_counter, err := reg.Authenticate(resp, c)
-    if err != nil {
-        // Authentication failed.
-    }
-    reg.Counter = new_counter
-    // Store updated Registration in the database.
+	var regs []Registration
+	// Fetch regs from the database.
+	c, _ := NewChallenge(app_id, []string{app_id})
+	req, _ := c.SignRequest(regs)
+	// Send the request to the browser.
+	var resp SignResponse
+	// Read resp from the browser.
+	new_counter, err := reg.Authenticate(resp, c)
+	if err != nil {
+	    // Authentication failed.
+	}
+	reg.Counter = new_counter
+	// Store updated Registration in the database.
 
 The FIDO U2F specification can be found here:
 https://fidoalliance.org/specifications/download
@@ -51,6 +51,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"time"
 )
@@ -104,13 +105,7 @@ func verifyClientData(clientData []byte, challenge Challenge) error {
 		return err
 	}
 
-	foundFacetID := false
-	for _, facetID := range challenge.TrustedFacets {
-		if facetID == cd.Origin {
-			foundFacetID = true
-			break
-		}
-	}
+	foundFacetID := slices.Contains(challenge.TrustedFacets, cd.Origin)
 	if !foundFacetID {
 		return errors.New("u2f: untrusted facet id")
 	}


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.