### PR TITLE
Fix certificate dropdown limitation in nodes page

### DIFF
--- a/www/app/components/Nodes.tsx
+++ b/www/app/components/Nodes.tsx
@@ -102,7 +102,7 @@ export default class Nodes extends React.Component<{}, State> {
 		NodeActions.sync();
 		ServiceActions.syncNames();
 		AuthorityActions.sync();
-		CertificateActions.sync();
+		CertificateActions.syncAll();
 
 		this.interval = setInterval(() => {
 			NodeActions.sync(true);


### PR DESCRIPTION
## Summary
Fixes the certificate dropdown in node configuration that was limited to 20 items, preventing users from selecting certificates beyond the first page.

## Problem
- The certificate dropdown in NodeDetailed component only showed first 20 certificates
- Users with more than 20 certificates couldn't access the full inventory
- Root cause: Nodes page was using paginated CertificatesStore (default 20 items)

## Changes
- ✨ **Add `syncAll()` function** - Fetches up to 10,000 certificates for dropdown usage
- 🔧 **Update Nodes component** - Use `syncAll()` instead of `sync()` on mount
- 🧹 **Refactor code** - Extract common callback logic to eliminate duplication
- 📝 **Maintain compatibility** - Certificate management pages keep existing pagination

## Test plan
- [ ] Create more than 20 certificates in Pritunl Zero
- [ ] Navigate to Nodes page and edit a node
- [ ] Verify "Add Certificate" dropdown shows all certificates (not just first 20)
- [ ] Confirm certificate management page still uses pagination correctly
- [ ] Test that certificate selection and saving works properly

## Technical Details
- Added `createSyncCallback()` helper to avoid code duplication
- `syncAll()` requests `page_count: 10000` to effectively get all certificates
- Only affects nodes page certificate loading, not the main certificates page
- Backend API already supported high page counts, no server changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)