### PR TITLE
refactor: use strings.builder

### DIFF
--- a/mhandlers/authority.go
+++ b/mhandlers/authority.go
@@ -431,7 +431,7 @@ func authorityPublicKeyGet(c *gin.Context) {
 		return
 	}
 
-	publicKeys := ""
+	var publicKeys strings.Builder
 
 	authrs, err := authority.GetMulti(db, authrIds)
 	if err != nil {
@@ -439,10 +439,10 @@ func authorityPublicKeyGet(c *gin.Context) {
 	}
 
 	for _, authr := range authrs {
-		publicKeys += strings.TrimSpace(authr.PublicKey) + "\n"
+		publicKeys.WriteString(strings.TrimSpace(authr.PublicKey) + "\n")
 	}
 
-	c.String(200, publicKeys)
+	c.String(200, publicKeys.String())
 }
 
 func authorityTokenPost(c *gin.Context) {

--- a/requires/requires.go
+++ b/requires/requires.go
@@ -5,6 +5,7 @@ import (
 	"container/list"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dropbox/godropbox/container/set"
 )
@@ -78,16 +79,17 @@ Loop:
 		i := modules.Front()
 		for i != nil {
 			module := i.Value.(*Module)
-			line := module.name
+			var line strings.Builder
+			line.WriteString(module.name)
 
 			for val := range module.before.Iter() {
-				line += fmt.Sprintf("   before: %s", val.(string))
+				line.WriteString(fmt.Sprintf("   before: %s", val.(string)))
 			}
 			for val := range module.after.Iter() {
-				line += fmt.Sprintf("   after: %s", val.(string))
+				line.WriteString(fmt.Sprintf("   after: %s", val.(string)))
 			}
 
-			fmt.Fprint(os.Stderr, line+"\n")
+			fmt.Fprint(os.Stderr, line.String()+"\n")
 			i = i.Next()
 		}
 

--- a/twilio/utils.go
+++ b/twilio/utils.go
@@ -2,6 +2,7 @@ package twilio
 
 import (
 	"github.com/dropbox/godropbox/container/set"
+	"strings"
 )
 
 var safeCharsPhone = set.NewSet(
@@ -172,14 +173,14 @@ func filterStr(s string, n int, safe set.Set) string {
 		s = s[:n]
 	}
 
-	ns := ""
+	var ns strings.Builder
 	for _, c := range s {
 		if safe.Contains(c) {
-			ns += string(c)
+			ns.WriteString(string(c))
 		}
 	}
 
-	return ns
+	return ns.String()
 }
 
 func FilterStrPhone(s string, n int) string {

--- a/utils/filter.go
+++ b/utils/filter.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/dropbox/godropbox/container/set"
+	"strings"
 )
 
 const nameSafeLimit = 128
@@ -81,12 +82,12 @@ func FilterName(s string) string {
 		s = s[:nameSafeLimit]
 	}
 
-	ns := ""
+	var ns strings.Builder
 	for _, c := range s {
 		if safeChars.Contains(c) {
-			ns += string(c)
+			ns.WriteString(string(c))
 		}
 	}
 
-	return ns
+	return ns.String()
 }

--- a/utils/misc.go
+++ b/utils/misc.go
@@ -170,14 +170,14 @@ func FilterStr(s string, n int) string {
 		s = s[:n]
 	}
 
-	ns := ""
+	var ns strings.Builder
 	for _, c := range s {
 		if safeChars.Contains(c) {
-			ns += string(c)
+			ns.WriteString(string(c))
 		}
 	}
 
-	return ns
+	return ns.String()
 }
 
 func FilterUnixStr(s string, n int) string {
@@ -189,14 +189,14 @@ func FilterUnixStr(s string, n int) string {
 		s = s[:n]
 	}
 
-	ns := ""
+	var ns strings.Builder
 	for _, c := range s {
 		if unixSafeChars.Contains(c) {
-			ns += string(c)
+			ns.WriteString(string(c))
 		}
 	}
 
-	return ns
+	return ns.String()
 }
 
 func PointerBool(x bool) *bool {


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)