### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/aggregate/completion.go
+++ b/aggregate/completion.go
@@ -16,8 +16,8 @@ type Completion struct {
 }
 
 func get(db *database.Database, coll *database.Collection,
-	query, projection *bson.M, new func() interface{},
-	add func(interface{})) (err error) {
+	query, projection *bson.M, new func() any,
+	add func(any)) (err error) {
 
 	cursor, err := coll.Find(db, query, options.Find().
 		SetProjection(projection))
@@ -62,10 +62,10 @@ func GetCompletion(db *database.Database, orgId bson.ObjectID) (
 			"cpu_units_res":    1,
 			"memory_units_res": 1,
 		},
-		func() interface{} {
+		func() any {
 			return &node.Node{}
 		},
-		func(item interface{}) {
+		func(item any) {
 			nde := item.(*node.Node)
 
 			cmpl.Nodes = append(
@@ -88,10 +88,10 @@ func GetCompletion(db *database.Database, orgId bson.ObjectID) (
 			"organization": 1,
 			"type":         1,
 		},
-		func() interface{} {
+		func() any {
 			return &certificate.Certificate{}
 		},
-		func(item interface{}) {
+		func(item any) {
 			cmpl.Certificates = append(
 				cmpl.Certificates,
 				item.(*certificate.Certificate),
@@ -112,10 +112,10 @@ func GetCompletion(db *database.Database, orgId bson.ObjectID) (
 			"organization": 1,
 			"type":         1,
 		},
-		func() interface{} {
+		func() any {
 			return &secret.Secret{}
 		},
-		func(item interface{}) {
+		func(item any) {
 			cmpl.Secrets = append(
 				cmpl.Secrets,
 				item.(*secret.Secret),

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pritunl/pritunl-zero/useragent"
 )
 
-type Fields map[string]interface{}
+type Fields map[string]any
 
 type Audit struct {
 	Id        bson.ObjectID    `bson:"_id,omitempty" json:"id"`

--- a/auth/state.go
+++ b/auth/state.go
@@ -9,9 +9,9 @@ import (
 )
 
 type StateProvider struct {
-	Id    interface{} `json:"id"`
-	Type  string      `json:"type"`
-	Label string      `json:"label"`
+	Id    any    `json:"id"`
+	Type  string `json:"type"`
+	Label string `json:"label"`
 }
 
 type StateProviders []*StateProvider

--- a/authority/hsm.go
+++ b/authority/hsm.go
@@ -51,7 +51,7 @@ func (h *HsmEvent) GetId() bson.ObjectID {
 	return h.Id
 }
 
-func (h *HsmEvent) GetData() interface{} {
+func (h *HsmEvent) GetData() any {
 	if h.Data == nil {
 		return nil
 	}

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -34,7 +34,7 @@ var SetCmd = &cobra.Command{
 		key := args[1]
 		val := args[2]
 
-		var valParsed interface{}
+		var valParsed any
 		err := json.Unmarshal([]byte(val), &valParsed)
 		if err != nil {
 			err = &errortypes.ParseError{

--- a/database/collection.go
+++ b/database/collection.go
@@ -16,7 +16,7 @@ type Collection struct {
 	*mongo.Collection
 }
 
-func (c *Collection) FindOneId(id interface{}, data interface{}) (err error) {
+func (c *Collection) FindOneId(id any, data any) (err error) {
 	err = c.FindOne(c.db, &bson.M{
 		"_id": id,
 	}).Decode(data)
@@ -28,7 +28,7 @@ func (c *Collection) FindOneId(id interface{}, data interface{}) (err error) {
 	return
 }
 
-func (c *Collection) UpdateId(id interface{}, data interface{}) (err error) {
+func (c *Collection) UpdateId(id any, data any) (err error) {
 	_, err = c.UpdateOne(c.db, &bson.M{
 		"_id": id,
 	}, data)
@@ -40,7 +40,7 @@ func (c *Collection) UpdateId(id interface{}, data interface{}) (err error) {
 	return
 }
 
-func (c *Collection) Commit(id interface{}, data interface{}) (err error) {
+func (c *Collection) Commit(id any, data any) (err error) {
 	_, err = c.UpdateOne(c.db, &bson.M{
 		"_id": id,
 	}, &bson.M{
@@ -54,7 +54,7 @@ func (c *Collection) Commit(id interface{}, data interface{}) (err error) {
 	return
 }
 
-func (c *Collection) CommitFields(id interface{}, data interface{},
+func (c *Collection) CommitFields(id any, data any,
 	fields set.Set) (err error) {
 
 	_, err = c.UpdateOne(c.db, &bson.M{
@@ -68,7 +68,7 @@ func (c *Collection) CommitFields(id interface{}, data interface{},
 	return
 }
 
-func (c *Collection) Upsert(query *bson.M, data interface{}) (err error) {
+func (c *Collection) Upsert(query *bson.M, data any) (err error) {
 	opts := options.UpdateOne().SetUpsert(true)
 
 	_, err = c.UpdateOne(c.db, query, bson.M{
@@ -81,7 +81,7 @@ func (c *Collection) Upsert(query *bson.M, data interface{}) (err error) {
 	return
 }
 
-func SelectFields(obj interface{}, fields set.Set) (data bson.M) {
+func SelectFields(obj any, fields set.Set) (data bson.M) {
 	val := reflect.ValueOf(obj).Elem()
 	data = bson.M{}
 
@@ -165,7 +165,7 @@ func SelectFields(obj interface{}, fields set.Set) (data bson.M) {
 	return
 }
 
-func SelectFieldsAll(obj interface{}, fields set.Set) (data bson.M) {
+func SelectFieldsAll(obj any, fields set.Set) (data bson.M) {
 	val := reflect.ValueOf(obj).Elem()
 
 	dataSet := bson.M{}
@@ -275,8 +275,8 @@ type ArraySelectFields struct {
 	count       int
 	setFields   bson.M
 	unsetFields bson.M
-	filters     []interface{}
-	push        []interface{}
+	filters     []any
+	push        []any
 	pull        []bson.ObjectID
 	rootKey     string
 	idKey       string
@@ -306,7 +306,7 @@ func (a *ArraySelectFields) Update(docId bson.ObjectID,
 	})
 }
 
-func (a *ArraySelectFields) Push(doc interface{}) {
+func (a *ArraySelectFields) Push(doc any) {
 	a.modified = true
 	a.push = append(a.push, doc)
 }
@@ -316,7 +316,7 @@ func (a *ArraySelectFields) Delete(docId bson.ObjectID) {
 	a.pull = append(a.pull, docId)
 }
 
-func (a *ArraySelectFields) GetQuery() (query bson.M, filters []interface{}) {
+func (a *ArraySelectFields) GetQuery() (query bson.M, filters []any) {
 	query = bson.M{}
 	if len(a.setFields) > 0 {
 		query["$set"] = a.setFields
@@ -348,7 +348,7 @@ func (a *ArraySelectFields) GetQuery() (query bson.M, filters []interface{}) {
 	return
 }
 
-func NewArraySelectFields(obj interface{}, rootKey string, fields set.Set) (
+func NewArraySelectFields(obj any, rootKey string, fields set.Set) (
 	arraySel *ArraySelectFields) {
 
 	selectFields := SelectFieldsAll(obj, fields)
@@ -363,8 +363,8 @@ func NewArraySelectFields(obj interface{}, rootKey string, fields set.Set) (
 		count:       1,
 		setFields:   setFields,
 		unsetFields: unsetFields,
-		filters:     []interface{}{},
-		push:        []interface{}{},
+		filters:     []any{},
+		push:        []any{},
 		pull:        []bson.ObjectID{},
 		rootKey:     rootKey,
 		idKey:       "id",

--- a/database/database.go
+++ b/database/database.go
@@ -45,7 +45,7 @@ func (d *Database) Err() error {
 	return nil
 }
 
-func (d *Database) Value(key interface{}) interface{} {
+func (d *Database) Value(key any) any {
 	if d.ctx != nil {
 		return d.ctx.Value(key)
 	}

--- a/database/index.go
+++ b/database/index.go
@@ -22,7 +22,7 @@ type Index struct {
 	Collection *Collection
 	Keys       *bson.D
 	Unique     bool
-	Partial    interface{}
+	Partial    any
 	Expire     time.Duration
 }
 

--- a/demo/demo.go
+++ b/demo/demo.go
@@ -156,7 +156,7 @@ var Logs = []*log.Entry{
 		Timestamp: time.Unix(1498018860, 0),
 		Message:   "router: Starting redirect server",
 		Stack:     "",
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"port":       80,
 			"production": true,
 			"protocol":   "http",
@@ -168,7 +168,7 @@ var Logs = []*log.Entry{
 		Timestamp: time.Unix(1498018860, 0),
 		Message:   "router: Starting web server",
 		Stack:     "",
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"port":       443,
 			"production": true,
 			"protocol":   "https",

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -26,8 +26,8 @@ type Doc interface {
 }
 
 type Point struct {
-	X int64       `json:"x"`
-	Y interface{} `json:"y"`
+	X int64 `json:"x"`
+	Y any   `json:"y"`
 }
 
 type ChartData = map[string][]*Point
@@ -123,14 +123,14 @@ type Chart struct {
 	curTimes map[string]int64
 }
 
-func (c *Chart) add(resource string, timestamp int64, value interface{}) {
+func (c *Chart) add(resource string, timestamp int64, value any) {
 	c.data[resource] = append(c.data[resource], &Point{
 		X: timestamp,
 		Y: value,
 	})
 }
 
-func (c *Chart) Add(resource string, timestamp int64, value interface{}) {
+func (c *Chart) Add(resource string, timestamp int64, value any) {
 	cur := c.curTimes[resource]
 	if cur == 0 {
 		cur = c.start - c.intv

--- a/event/event.go
+++ b/event/event.go
@@ -29,12 +29,12 @@ type EventPublish struct {
 	Id        bson.ObjectID `bson:"_id,omitempty" json:"id"`
 	Channel   string        `bson:"channel" json:"channel"`
 	Timestamp time.Time     `bson:"timestamp" json:"timestamp"`
-	Data      interface{}   `bson:"data" json:"data"`
+	Data      any           `bson:"data" json:"data"`
 }
 
 type CustomEvent interface {
 	GetId() bson.ObjectID
-	GetData() interface{}
+	GetData() any
 }
 
 type Dispatch struct {
@@ -121,7 +121,7 @@ func getCursorIdRetry(channels []string) bson.ObjectID {
 	}
 }
 
-func Publish(db *database.Database, channel string, data interface{}) (
+func Publish(db *database.Database, channel string, data any) (
 	err error) {
 
 	coll := db.Events()
@@ -166,7 +166,7 @@ func Subscribe(channels []string, duration time.Duration,
 
 	cursorId := getCursorIdRetry(channels)
 
-	var channelBson interface{}
+	var channelBson any
 	if len(channels) == 1 {
 		channelBson = channels[0]
 	} else {
@@ -312,7 +312,7 @@ func SubscribeType(channels []string, duration time.Duration,
 
 	cursorId := getCursorIdRetry(channels)
 
-	var channelBson interface{}
+	var channelBson any
 	if len(channels) == 1 {
 		channelBson = channels[0]
 	} else {

--- a/event/listener.go
+++ b/event/listener.go
@@ -36,7 +36,7 @@ func (l *Listener) Close() {
 func (l *Listener) sub(cursorId bson.ObjectID) {
 	coll := l.db.Events()
 
-	var channelBson interface{}
+	var channelBson any
 	if len(l.channels) == 1 {
 		channelBson = l.channels[0]
 	} else {

--- a/log/log.go
+++ b/log/log.go
@@ -14,12 +14,12 @@ import (
 var published = false
 
 type Entry struct {
-	Id        bson.ObjectID          `bson:"_id,omitempty" json:"id"`
-	Level     string                 `bson:"level" json:"level"`
-	Timestamp time.Time              `bson:"timestamp" json:"timestamp"`
-	Message   string                 `bson:"message" json:"message"`
-	Stack     string                 `bson:"stack" json:"stack"`
-	Fields    map[string]interface{} `bson:"fields" json:"fields"`
+	Id        bson.ObjectID  `bson:"_id,omitempty" json:"id"`
+	Level     string         `bson:"level" json:"level"`
+	Timestamp time.Time      `bson:"timestamp" json:"timestamp"`
+	Message   string         `bson:"message" json:"message"`
+	Stack     string         `bson:"stack" json:"stack"`
+	Fields    map[string]any `bson:"fields" json:"fields"`
 }
 
 func (e *Entry) Insert(db *database.Database) (err error) {

--- a/logger/database.go
+++ b/logger/database.go
@@ -60,7 +60,7 @@ func databaseSend(entry *logrus.Entry) (err error) {
 		Level:     level,
 		Timestamp: entry.Time,
 		Message:   entry.Message,
-		Fields:    map[string]interface{}{},
+		Fields:    map[string]any{},
 	}
 
 	for key, val := range entry.Data {

--- a/mhandlers/devices.go
+++ b/mhandlers/devices.go
@@ -234,8 +234,8 @@ func deviceMethodPost(c *gin.Context) {
 }
 
 type devicesWanRegisterRespData struct {
-	Token   string      `json:"token"`
-	Options interface{} `json:"options"`
+	Token   string `json:"token"`
+	Options any    `json:"options"`
 }
 
 func deviceWanRegisterGet(c *gin.Context) {

--- a/mhandlers/endpoint.go
+++ b/mhandlers/endpoint.go
@@ -35,8 +35,8 @@ type endpointsData struct {
 }
 
 type endpointChartData struct {
-	HasData bool        `json:"has_data"`
-	Data    interface{} `json:"data"`
+	HasData bool `json:"has_data"`
+	Data    any  `json:"data"`
 }
 
 func endpointPut(c *gin.Context) {

--- a/search/document.go
+++ b/search/document.go
@@ -17,7 +17,7 @@ import (
 type Document struct {
 	Index    string
 	Id       string
-	Data     interface{}
+	Data     any
 	NoRetry  bool
 	attempts int
 }
@@ -31,7 +31,7 @@ type searchBulkReq struct {
 	Index *searchBulkReqData `json:"index"`
 }
 
-func Index(index string, data interface{}, noRetry bool) {
+func Index(index string, data any, noRetry bool) {
 	clnt := Default
 
 	if clnt == nil {

--- a/search/index.go
+++ b/search/index.go
@@ -40,7 +40,7 @@ type searchMappingObject struct {
 	Enabled bool `json:"enabled"`
 }
 
-type searchMappings map[string]interface{}
+type searchMappings map[string]any
 
 type searchProperties struct {
 	Properties searchMappings `json:"properties"`

--- a/secondary/secondary.go
+++ b/secondary/secondary.go
@@ -324,7 +324,7 @@ func (s *Secondary) Sms(db *database.Database, r *http.Request) (
 }
 
 func (s *Secondary) DeviceRegisterRequest(db *database.Database,
-	origin string) (jsonResp interface{}, errData *errortypes.ErrorData,
+	origin string) (jsonResp any, errData *errortypes.ErrorData,
 	err error) {
 
 	if s.Disabled {
@@ -447,7 +447,7 @@ func (s *Secondary) DeviceRegisterResponse(db *database.Database,
 }
 
 func (s *Secondary) DeviceRequest(db *database.Database, origin string) (
-	jsonResp interface{}, errData *errortypes.ErrorData, err error) {
+	jsonResp any, errData *errortypes.ErrorData, err error) {
 
 	if s.Disabled {
 		errData = &errortypes.ErrorData{

--- a/service/service.go
+++ b/service/service.go
@@ -278,10 +278,10 @@ func init() {
 			"whitelist_networks": nil,
 		}, &bson.M{
 			"$set": &bson.M{
-				"domains":            []interface{}{},
-				"roles":              []interface{}{},
-				"servers":            []interface{}{},
-				"whitelist_networks": []interface{}{},
+				"domains":            []any{},
+				"roles":              []any{},
+				"servers":            []any{},
+				"whitelist_networks": []any{},
 			},
 		})
 		if err != nil {

--- a/settings/acme.go
+++ b/settings/acme.go
@@ -13,13 +13,13 @@ type acme struct {
 	DnsOracleCloudTtl int    `bson:"dns_oracle_cloud_ttl" default:"30"`
 }
 
-func newAcme() interface{} {
+func newAcme() any {
 	return &acme{
 		Id: "acme",
 	}
 }
 
-func updateAcme(data interface{}) {
+func updateAcme(data any) {
 	Acme = data.(*acme)
 }
 

--- a/settings/auth.go
+++ b/settings/auth.go
@@ -257,7 +257,7 @@ func (a *auth) GetSecondaryProvider(id bson.ObjectID) *SecondaryProvider {
 	return nil
 }
 
-func newAuth() interface{} {
+func newAuth() any {
 	return &auth{
 		Id:                 "auth",
 		Providers:          []*Provider{},
@@ -265,7 +265,7 @@ func newAuth() interface{} {
 	}
 }
 
-func updateAuth(data interface{}) {
+func updateAuth(data any) {
 	Auth = data.(*auth)
 }
 

--- a/settings/elastic.go
+++ b/settings/elastic.go
@@ -10,13 +10,13 @@ type elastic struct {
 	ProxyRequests bool     `bson:"proxy_requests"`
 }
 
-func newElastic() interface{} {
+func newElastic() any {
 	return &elastic{
 		Id: "elastic",
 	}
 }
 
-func updateElastic(data interface{}) {
+func updateElastic(data any) {
 	Elastic = data.(*elastic)
 }
 

--- a/settings/endpoint.go
+++ b/settings/endpoint.go
@@ -9,13 +9,13 @@ type endpoint struct {
 	CheckDisplayLimit int64  `bson:"check_display_limit" default:"5000"`
 }
 
-func newEndpoint() interface{} {
+func newEndpoint() any {
 	return &endpoint{
 		Id: "endpoint",
 	}
 }
 
-func updateEndpoint(data interface{}) {
+func updateEndpoint(data any) {
 	Endpoint = data.(*endpoint)
 }
 

--- a/settings/registry.go
+++ b/settings/registry.go
@@ -4,8 +4,8 @@ var (
 	registry = map[string]*group{}
 )
 
-type newFunc func() interface{}
-type updateFunc func(interface{})
+type newFunc func() any
+type updateFunc func(any)
 
 type group struct {
 	New    newFunc

--- a/settings/router.go
+++ b/settings/router.go
@@ -27,13 +27,13 @@ type router struct {
 	SkipVerify             bool   `bson:"skip_verify"`
 }
 
-func newRouter() interface{} {
+func newRouter() any {
 	return &router{
 		Id: "router",
 	}
 }
 
-func updateRouter(data interface{}) {
+func updateRouter(data any) {
 	Router = data.(*router)
 }
 

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Commit(db *database.Database, group interface{}, fields set.Set) (
+func Commit(db *database.Database, group any, fields set.Set) (
 	err error) {
 
 	coll := db.Settings()
@@ -43,11 +43,11 @@ func Commit(db *database.Database, group interface{}, fields set.Set) (
 }
 
 func Get(db *database.Database, group string, key string) (
-	val interface{}, err error) {
+	val any, err error) {
 
 	coll := db.Settings()
 
-	grp := map[string]interface{}{}
+	grp := map[string]any{}
 
 	err = coll.FindOne(
 		db,
@@ -76,7 +76,7 @@ func Get(db *database.Database, group string, key string) (
 	return
 }
 
-func Set(db *database.Database, group string, key string, val interface{}) (
+func Set(db *database.Database, group string, key string, val any) (
 	err error) {
 
 	coll := db.Settings()
@@ -126,7 +126,7 @@ func Unset(db *database.Database, group string, key string) (
 	return
 }
 
-func setDefaults(obj interface{}) {
+func setDefaults(obj any) {
 	val := reflect.ValueOf(obj)
 	elm := val.Elem()
 

--- a/settings/system.go
+++ b/settings/system.go
@@ -28,13 +28,13 @@ type system struct {
 	TwilioNumber                   string `bson:"twilio_number"`
 }
 
-func newSystem() interface{} {
+func newSystem() any {
 	return &system{
 		Id: "system",
 	}
 }
 
-func updateSystem(data interface{}) {
+func updateSystem(data any) {
 	System = data.(*system)
 }
 

--- a/uhandlers/devices.go
+++ b/uhandlers/devices.go
@@ -192,8 +192,8 @@ func devicesGet(c *gin.Context) {
 }
 
 type devicesWanRegisterRespData struct {
-	Token   string      `json:"token"`
-	Options interface{} `json:"options"`
+	Token   string `json:"token"`
+	Options any    `json:"options"`
 }
 
 func deviceWanRegisterGet(c *gin.Context) {
@@ -527,7 +527,7 @@ func deviceSecondaryPut(c *gin.Context) {
 		return
 	}
 
-	var jsonResp interface{}
+	var jsonResp any
 	if data.DeviceType != device.SmartCard {
 		jsonResp, errData, err = secd.DeviceRegisterRequest(db,
 			utils.GetOrigin(c.Request))
@@ -697,7 +697,7 @@ func deviceWanRespondPost(c *gin.Context) {
 		return
 	}
 
-	var jsonResp interface{}
+	var jsonResp any
 	if data.DeviceType != device.SmartCard {
 		jsonResp, errData, err = secd.DeviceRegisterRequest(db,
 			utils.GetOrigin(c.Request))


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.