### PR TITLE
feat: bastion - customize PermitOpen ports

### DIFF
--- a/bastion/bastion.go
+++ b/bastion/bastion.go
@@ -186,6 +186,8 @@ func (b *Bastion) Start(db *database.Database,
 			"BASTION_HOST_KEY=%s", authr.ProxyPrivateKey),
 		"-e", fmt.Sprintf(
 			"BASTION_HOST_PUB_KEY=%s", authr.ProxyPublicKey),
+		"-e", fmt.Sprintf(
+			"BASTION_PERMIT_OPEN=%s", settings.System.BastionPermitOpen),
 		settings.System.BastionDockerImage,
 	)
 	if err != nil {

--- a/settings/system.go
+++ b/settings/system.go
@@ -22,6 +22,7 @@ type system struct {
 	HsmResponseTimeout             int    `bson:"hsm_response_timeout" default:"10"`
 	DisableBastionHostCertificates bool   `bson:"disable_bastion_host_certificates"`
 	BastionDockerImage             string `bson:"bastion_docker_image" default:"docker.io/pritunl/pritunl-bastion"`
+	BastionPermitOpen              string `bson:"bastion_permit_open" default:"*:22"`
 	ClientCertCacheTtl             int    `bson:"client_cert_cache_ttl" default:"60"`
 	TwilioAccount                  string `bson:"twilio_account"`
 	TwilioSecret                   string `bson:"twilio_secret"`


### PR DESCRIPTION
Adds a new system setting `bastion_permit_open` (default `*:22`) and passes it to the bastion container as `BASTION_PERMIT_OPEN`. This lets operators configure which downstream `host:port` patterns the bastion's SSH `PermitOpen` directive allows, without rebuilding the bastion image.

The default preserves existing behavior. Settable via:
```
pritunl-zero set system bastion_permit_open '"*:22 *:12345"'
```

Requires the pritunl-bastion change https://github.com/pritunl/pritunl-bastion/pull/3