### PR TITLE
fix CSRF check for Origin: null

### DIFF
--- a/auth/utils.go
+++ b/auth/utils.go
@@ -123,7 +123,11 @@ func CsrfCheck(w http.ResponseWriter, r *http.Request, domain string,
 			utils.WriteUnauthorized(w, "CSRF origin invalid")
 			return false
 		}
-		origin = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		if u.Scheme == "" && u.Host == "" {
+			origin = ""
+		} else {
+			origin = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		}
 	}
 
 	if wildcard {


### PR DESCRIPTION
We run an internal app behind pritunl-zero and hit a weird problem: 

the app loads fine in Chrome/Safari but breaks in Firefox...  
some people on Brave hit it the bug but for other it worked fine

After some debugging we caught it in the network tab and saw that the failing static .js GET request had:

```
401 CSRF origin error
```

Disabling pritunl-zero fixed the problem but we wanted to understand why

Luckily we saw that there was a difference between the working and broken requests: the origin header!  
for broken users we saw they were sending `Origin: null` while working ones send a none origin at all

The problem comes from `CsrfCheck` in auth/utils.go (called from proxy/proxy.go on every request):

```go
origin := r.Header.Get("Origin")   // "null"
if origin != "" {                  // not empty so we go in here
    u, err := url.Parse(origin)    // no error, url.Parse("null") is fine
    origin = fmt.Sprintf("%s://%s", u.Scheme, u.Host)  // -> "://"
}
// "://" != "https://ourdomain" -> 401
```

`url.Parse("null")` doesn't error it parses to an empty scheme+host, and that gets turned into `"://"` which never matches our domain so it is a `401`

The `Origin: null` is sent by browsers for opaque origins (sandboxed `<iframe>` with `blob:/data:` or `srcDoc`)

Here is a minimal reproduction a sandboxed iframe with an opaque origin so its request goes out with `Origin: null`  
serve over http, open in firefox, look at the `/probe.js` request in the network panel:

```html
<!doctype html>
<iframe sandbox="allow-scripts" srcdoc='<script src="/probe.js"></script>'></iframe>
```

You will see it hits the server with `Origin: null` and behind pritunl-zero that's a **401**

I logged what actually sends `Origin: null` and that helped us to find out why it worked for some users but not for others:

| Firefox 152 | Chrome 149 | Chrome Canary | Safari 26.5 | iOS Safari | Brave Shields on | Brave Shields off |
|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| `null` <br>❌ 401 | none <br>✅ ok | none <br>✅ ok | none <br>✅ ok | none <br>✅ ok | `null` <br>❌ 401 | none <br>✅ ok |

So Firefox and Brave (with shields) users send `null` and get the 401
But **everyone else sends no origin and just works** which matches exactly the error reports we got by our users

## the fix

this pr handles `null` by allowing an opaque origin (`Origin: null`, which `url.Parse` turns into an empty scheme and host) is treated as empty and allowed instead of being rebuilt into `"://"` and rejected

**‼️ Disclaimer:** This code change was drafted with the assistance of Claude (Anthropic). It has been **manually reviewed and tested** by me before submission