### PR TITLE
Fix resource name character filtering

### DIFF
--- a/utils/filter.go
+++ b/utils/filter.go
@@ -84,7 +84,7 @@ func FilterName(s string) string {
 
 	var ns strings.Builder
 	for _, c := range s {
-		if safeChars.Contains(c) {
+		if nameSafeChar.Contains(c) {
 			ns.WriteString(string(c))
 		}
 	}

--- a/utils/filter_test.go
+++ b/utils/filter_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "allowed characters",
+			input:    "Alpha-123",
+			expected: "Alpha-123",
+		},
+		{
+			name:     "unsupported characters",
+			input:    "alpha beta/_@#",
+			expected: "alphabeta",
+		},
+		{
+			name:     "length limit",
+			input:    strings.Repeat("a", nameSafeLimit+1),
+			expected: strings.Repeat("a", nameSafeLimit),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := FilterName(test.input)
+			if result != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Use the dedicated `nameSafeChar` set when filtering resource names
- Prevent unsupported characters such as spaces, slashes, underscores, and symbols from passing through
- Add tests covering allowed characters, unsupported characters, and the name length limit

## Testing

- `go test ./...`
- `go test -race ./utils -run '^TestFilterName$' -count=1`
- `go vet -composites=false ./utils`